### PR TITLE
feat: Add Auth0 API outputs and configure authentication settings

### DIFF
--- a/configurations/platform/environments/development/appsettings.json
+++ b/configurations/platform/environments/development/appsettings.json
@@ -7,6 +7,14 @@
     "GrainsConfig": {
       "StorageAccountName": "$(PLATFORM_GRAIN_STORAGE_ACCOUNT_NAME)"
     },
+    "AuthenticationSettings": {
+      "Auth0": {
+        "Domain": "$(AUTH0_API_DOMAIN)",
+        "ClientId": "$(AUTH0_API_DOC_CLIENT_ID)",
+        "ClientSecret": "$(AUTH0_API_DOC_CLIENT_SECRET)",
+        "Audience": "$(AUTH0_API_AUDIENCE)"
+      }
+    },
     "Logging": {
       "LogLevel": {
         "Default": "Information",

--- a/configurations/platform/environments/production/appsettings.json
+++ b/configurations/platform/environments/production/appsettings.json
@@ -7,6 +7,14 @@
         "GrainsConfig": {
             "StorageAccountName": "$(PLATFORM_GRAIN_STORAGE_ACCOUNT_NAME)"
         },
+        "AuthenticationSettings": {
+            "Auth0": {
+                "Domain": "$(AUTH0_API_DOMAIN)",
+                "ClientId": "$(AUTH0_API_DOC_CLIENT_ID)",
+                "ClientSecret": "$(AUTH0_API_DOC_CLIENT_SECRET)",
+                "Audience": "$(AUTH0_API_AUDIENCE)"
+            }
+        },
         "Logging": {
             "LogLevel": {
                 "Default": "Information",

--- a/configurations/platform/environments/qa/appsettings.json
+++ b/configurations/platform/environments/qa/appsettings.json
@@ -7,6 +7,14 @@
         "GrainsConfig": {
             "StorageAccountName": "$(PLATFORM_GRAIN_STORAGE_ACCOUNT_NAME)"
         },
+        "AuthenticationSettings": {
+            "Auth0": {
+                "Domain": "$(AUTH0_API_DOMAIN)",
+                "ClientId": "$(AUTH0_API_DOC_CLIENT_ID)",
+                "ClientSecret": "$(AUTH0_API_DOC_CLIENT_SECRET)",
+                "Audience": "$(AUTH0_API_AUDIENCE)"
+            }
+        },
         "Logging": {
             "LogLevel": {
                 "Default": "Information",

--- a/configurations/platform/environments/staging/appsettings.json
+++ b/configurations/platform/environments/staging/appsettings.json
@@ -7,6 +7,14 @@
         "GrainsConfig": {
             "StorageAccountName": "$(PLATFORM_GRAIN_STORAGE_ACCOUNT_NAME)"
         },
+        "AuthenticationSettings": {
+            "Auth0": {
+                "Domain": "$(AUTH0_API_DOMAIN)",
+                "ClientId": "$(AUTH0_API_DOC_CLIENT_ID)",
+                "ClientSecret": "$(AUTH0_API_DOC_CLIENT_SECRET)",
+                "Audience": "$(AUTH0_API_AUDIENCE)"
+            }
+        },
         "Logging": {
             "LogLevel": {
                 "Default": "Information",


### PR DESCRIPTION
## Summary
This PR adds the required Auth0 outputs to the Terraform module and configures authentication settings across all platform environments.

## Changes

### Infrastructure (Terraform)
- Added `api_audience` output for Auth0 API audience/identifier
- Added `api_domain` output for Auth0 domain
- Renamed `api_identifier` to `api_audience` for better clarity and standard Auth0 terminology
- Organized outputs into logical sections with comments (API, Web App, API Doc)

### Configuration (appsettings)
- Added `AuthenticationSettings.Auth0` configuration block to all platform environment appsettings:
  - development
  - staging
  - qa
  - production
- Each configuration includes:
  - Domain: `$(AUTH0_API_DOMAIN)`
  - ClientId: `$(AUTH0_API_DOC_CLIENT_ID)`
  - ClientSecret: `$(AUTH0_API_DOC_CLIENT_SECRET)`
  - Audience: `$(AUTH0_API_AUDIENCE)`

## Testing
- [ ] Verify Terraform outputs are available after deployment
- [ ] Verify CI/CD pipeline properly substitutes Auth0 configuration values
- [ ] Test application authentication in each environment

## Related Issues
Resolves authentication configuration for deployed APIs and applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Auth0 authentication configuration has been added across all environments (development, production, QA, and staging). Configuration includes domain, client credentials, and audience sourced from environment variables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->