### PR TITLE
Fix workflow syntax error: remove paths-ignore

### DIFF
--- a/.github/workflows/config-platform-deploy.yml
+++ b/.github/workflows/config-platform-deploy.yml
@@ -5,14 +5,10 @@ on:
     branches: [ main ]
     paths:
       - 'configurations/platform/**'
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches: [ main ]
     paths:
       - 'configurations/platform/**'
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/config-shared-deploy.yml
+++ b/.github/workflows/config-shared-deploy.yml
@@ -5,14 +5,10 @@ on:
     branches: [ main ]
     paths:
       - 'configurations/shared/**'
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches: [ main ]
     paths:
       - 'configurations/shared/**'
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/infra-auth0-deploy.yml
+++ b/.github/workflows/infra-auth0-deploy.yml
@@ -5,14 +5,10 @@ on:
     branches: [ main ]
     paths:
       - 'infra/auth0/**'
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches: [ main ]
     paths:
       - 'infra/auth0/**'
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/infra-mongodb-deploy.yml
+++ b/.github/workflows/infra-mongodb-deploy.yml
@@ -5,14 +5,10 @@ on:
     branches: [ main ]
     paths:
       - 'infra/mongodb/**'
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches: [ main ]
     paths:
       - 'infra/mongodb/**'
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/infra-platform-deploy.yml
+++ b/.github/workflows/infra-platform-deploy.yml
@@ -5,14 +5,10 @@ on:
     branches: [ main ]
     paths:
       - 'infra/platform/**'
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches: [ main ]
     paths:
       - 'infra/platform/**'
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/infra-shared-deploy.yml
+++ b/.github/workflows/infra-shared-deploy.yml
@@ -5,14 +5,10 @@ on:
     branches: [ main ]
     paths:
       - 'infra/shared/**'
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches: [ main ]
     paths:
       - 'infra/shared/**'
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

The deployment workflows are failing due to a syntax error with `paths-ignore` configuration.

**Error from pipeline:**
https://github.com/aytymchuk/Dilcore-Shared-InfraAsCode/actions/runs/20613751825/workflow

Closes #47

## Root Cause

The `paths-ignore` pattern was added to workflow files, but GitHub Actions does not support using `paths` and `paths-ignore` together in the same trigger. This causes a workflow syntax error.

## Solution

Removed the `paths-ignore` patterns from all deployment workflow files:
- ✅ infra-auth0-deploy.yml
- ✅ infra-mongodb-deploy.yml
- ✅ infra-platform-deploy.yml
- ✅ infra-shared-deploy.yml
- ✅ config-platform-deploy.yml
- ✅ config-shared-deploy.yml

## Changes

```diff
- paths-ignore:
-   - '**/*.md'
```

Removed from both `push` and `pull_request` triggers in all affected workflows.

## Testing

- Workflows should now pass syntax validation
- Deployments will trigger on any changes to their respective paths (including markdown files)