### PR TITLE
fix: Update Grain Storage Role to Table Data Contributor

### DIFF
--- a/infra/platform/main.tf
+++ b/infra/platform/main.tf
@@ -85,7 +85,7 @@ resource "azurerm_storage_account" "grain_storage_account" {
 # Add Storage Blob Data Contributor role assignment for the API
 resource "azurerm_role_assignment" "storage_access" {
   scope                = azurerm_storage_account.grain_storage_account.id
-  role_definition_name = "Storage Blob Data Contributor"
+  role_definition_name = "Storage Table Data Contributor"
   principal_id         = azurerm_container_app.api.identity[0].principal_id
 
   depends_on = [


### PR DESCRIPTION
Updates the role assignment for Grain Storage to 'Storage Table Data Contributor' as it uses Azure Tables for persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API service permissions to grant access to Table storage instead of Blob storage, modifying the storage resource tier used for data operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->