### PR TITLE
feat(config): add PlatformManagementDbSettings connection string

### DIFF
--- a/configurations/platform/environments/development/appsettings.json
+++ b/configurations/platform/environments/development/appsettings.json
@@ -17,6 +17,9 @@
         "Audience": "$(AUTH0_API_AUDIENCE)"
       }
     },
+    "PlatformManagementDbSettings": {
+      "ConnectionString": "$(PLATFORM_SQL_CONNECTION_STRING)"
+    },
     "Logging": {
       "LogLevel": {
         "Default": "Information",

--- a/configurations/platform/environments/production/appsettings.json
+++ b/configurations/platform/environments/production/appsettings.json
@@ -17,6 +17,9 @@
                 "Audience": "$(AUTH0_API_AUDIENCE)"
             }
         },
+        "PlatformManagementDbSettings": {
+            "ConnectionString": "$(PLATFORM_SQL_CONNECTION_STRING)"
+        },
         "Logging": {
             "LogLevel": {
                 "Default": "Information",

--- a/configurations/platform/environments/qa/appsettings.json
+++ b/configurations/platform/environments/qa/appsettings.json
@@ -17,6 +17,9 @@
                 "Audience": "$(AUTH0_API_AUDIENCE)"
             }
         },
+        "PlatformManagementDbSettings": {
+            "ConnectionString": "$(PLATFORM_SQL_CONNECTION_STRING)"
+        },
         "Logging": {
             "LogLevel": {
                 "Default": "Information",

--- a/configurations/platform/environments/staging/appsettings.json
+++ b/configurations/platform/environments/staging/appsettings.json
@@ -17,6 +17,9 @@
                 "Audience": "$(AUTH0_API_AUDIENCE)"
             }
         },
+        "PlatformManagementDbSettings": {
+            "ConnectionString": "$(PLATFORM_SQL_CONNECTION_STRING)"
+        },
         "Logging": {
             "LogLevel": {
                 "Default": "Information",


### PR DESCRIPTION
This PR adds the  section with a connection string placeholder to the  files for all environments. This prepares the configuration for SQL management connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform management database configuration settings across development, production, QA, and staging environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->