### PR TITLE
fix(mongodb): remove special characters from password generation

### DIFF
--- a/infra/mongodb/main.tf
+++ b/infra/mongodb/main.tf
@@ -7,12 +7,11 @@ resource "random_string" "db_username" {
 
 # Generate random password for database user
 resource "random_password" "db_password" {
-  length           = 16
-  special          = true
-  upper            = true
-  lower            = true
-  numeric          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
+  length  = 16
+  special = false
+  upper   = true
+  lower   = true
+  numeric = true
 }
 
 locals {


### PR DESCRIPTION
## Summary

Removed special characters from MongoDB Atlas database user password generation to avoid potential issues with connection strings and URL encoding.

## Changes

- Set `special = false` in the `random_password` resource
- Removed `override_special` configuration

The password will now only contain uppercase letters, lowercase letters, and numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated password generation configuration to use only alphanumeric characters, removing special character support while maintaining 16-character length requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->