### PR TITLE
feat(mongodb): grant cluster-level database access

### DIFF
--- a/infra/mongodb/main.tf
+++ b/infra/mongodb/main.tf
@@ -74,8 +74,8 @@ resource "mongodbatlas_database_user" "atlas_db_user" {
   auth_database_name = "admin"
 
   roles {
-    role_name     = "readWrite"
-    database_name = var.app_database_name
+    role_name     = "readWriteAnyDatabase"
+    database_name = "admin"
   }
 
   labels {

--- a/infra/mongodb/outputs.tf
+++ b/infra/mongodb/outputs.tf
@@ -9,6 +9,6 @@ output "project_name" {
 }
 output "mongodb_connection_string" {
   description = "The MongoDB connection string with credentials"
-  value       = "${replace(mongodbatlas_advanced_cluster.atlas_cluster.connection_strings.standard_srv, "mongodb+srv://", "mongodb+srv://${mongodbatlas_database_user.atlas_db_user.username}:${mongodbatlas_database_user.atlas_db_user.password}@")}/${var.app_database_name}"
+  value       = replace(mongodbatlas_advanced_cluster.atlas_cluster.connection_strings.standard_srv, "mongodb+srv://", "mongodb+srv://${mongodbatlas_database_user.atlas_db_user.username}:${mongodbatlas_database_user.atlas_db_user.password}@")
   sensitive   = true
 }

--- a/infra/mongodb/variables.tf
+++ b/infra/mongodb/variables.tf
@@ -130,12 +130,6 @@ variable "atlas_region_mapping" {
   }
 }
 
-variable "app_database_name" {
-  description = "Name of the application database for the database user"
-  type        = string
-  default     = "dilcore-app-db"
-}
-
 # MongoDB Atlas Cluster Configuration Variables
 variable "instance_size" {
   description = "MongoDB Atlas cluster instance size"


### PR DESCRIPTION
- Changed database user role from 'readWrite' on specific database to 'readWriteAnyDatabase' on admin
- Removed app_database_name variable and all its dependencies
- Updated connection string output to not include database name suffix
- User now has full read/write access to all databases and collections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Updated database user permissions to allow broader access across databases.
  * Simplified database connection string output by removing app-specific database path suffix.
  * Removed app database name configuration variable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->